### PR TITLE
Rename Firestore snapshot callback variable

### DIFF
--- a/src/screens/SectionScreen.js
+++ b/src/screens/SectionScreen.js
@@ -7,8 +7,8 @@ function SectionScreen({ userId, tripId, sectionId, onBack, apiKey, language, t,
     const [trip, setTrip] = useState(null);
     useEffect(() => {
         if (!userId || !tripId) return;
-        const unsub = onSnapshot(doc(db, `users/${userId}/trips/${tripId}`), (doc) => {
-            doc.exists() ? setTrip({ id: doc.id, ...doc.data() }) : onBack();
+        const unsub = onSnapshot(doc(db, `users/${userId}/trips/${tripId}`), (snap) => {
+            snap.exists() ? setTrip({ id: snap.id, ...snap.data() }) : onBack();
         });
         return () => unsub();
     }, [userId, tripId, onBack]);

--- a/src/screens/TripScreen.js
+++ b/src/screens/TripScreen.js
@@ -12,8 +12,8 @@ function TripScreen({ userId, tripId, onSelectSection, onBack, t, showNotificati
 
     useEffect(() => {
         if (!userId || !tripId) return;
-        const unsub = onSnapshot(doc(db, `users/${userId}/trips/${tripId}`), (doc) => {
-            doc.exists() ? setTrip({ id: doc.id, ...doc.data() }) : onBack();
+        const unsub = onSnapshot(doc(db, `users/${userId}/trips/${tripId}`), (snap) => {
+            snap.exists() ? setTrip({ id: snap.id, ...snap.data() }) : onBack();
         }, (error) => {
             console.error("Error fetching trip:", error);
             onBack();


### PR DESCRIPTION
## Summary
- rename the `doc` param to `snap` in `TripScreen` and `SectionScreen`
- update internal references to `snap`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855dcea696083269ae86477fc3f3ee8