### PR TITLE
Add PropTypes for components and screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^13.5.0",
         "firebase": "^11.9.1",
         "framer-motion": "^12.18.1",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "firebase": "^11.9.1",
     "framer-motion": "^12.18.1",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",

--- a/src/components/AddSectionModal.js
+++ b/src/components/AddSectionModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { doc, updateDoc } from 'firebase/firestore';
+import PropTypes from 'prop-types';
 import BaseModal from './BaseModal';
 import { db } from '../firebase/firebase';
 
@@ -38,3 +39,13 @@ export default function AddSectionModal({ isOpen, onClose, userId, tripId, exist
     </BaseModal>
   );
 }
+
+AddSectionModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
+  tripId: PropTypes.string.isRequired,
+  existingSections: PropTypes.array.isRequired,
+  t: PropTypes.object.isRequired,
+  showNotification: PropTypes.func.isRequired,
+};

--- a/src/components/AddTripModal.js
+++ b/src/components/AddTripModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import PropTypes from 'prop-types';
 import BaseModal from './BaseModal';
 import { db } from '../firebase/firebase';
 import { COLORS } from '../constants/colors';
@@ -54,3 +55,10 @@ export default function AddTripModal({ isOpen, onClose, userId, t }) {
     </BaseModal>
   );
 }
+
+AddTripModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
+  t: PropTypes.object.isRequired,
+};

--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import PropTypes from 'prop-types';
 
 export default function BaseModal({ isOpen, onClose, children }) {
   const modalRef = useRef();
@@ -25,3 +26,9 @@ export default function BaseModal({ isOpen, onClose, children }) {
     </AnimatePresence>
   );
 }
+
+BaseModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};

--- a/src/components/ConfirmationModal.js
+++ b/src/components/ConfirmationModal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import BaseModal from './BaseModal';
 
 export default function ConfirmationModal({ isOpen, onClose, onConfirm, title, message, t }) {
@@ -13,3 +14,12 @@ export default function ConfirmationModal({ isOpen, onClose, onConfirm, title, m
     </BaseModal>
   );
 }
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  t: PropTypes.object.isRequired,
+};

--- a/src/components/EditTripModal.js
+++ b/src/components/EditTripModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { doc, updateDoc } from 'firebase/firestore';
+import PropTypes from 'prop-types';
 import BaseModal from './BaseModal';
 import { db } from '../firebase/firebase';
 import { COLORS } from '../constants/colors';
@@ -52,3 +53,11 @@ export default function EditTripModal({ isOpen, onClose, userId, trip, t }) {
     </BaseModal>
   );
 }
+
+EditTripModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
+  trip: PropTypes.object,
+  t: PropTypes.object.isRequired,
+};

--- a/src/components/EditableItem.js
+++ b/src/components/EditableItem.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from "react";
 import { SparklesIcon } from "./icons";
 import { useAutosizeTextArea } from "../hooks/useAutosizeTextArea";
+import PropTypes from "prop-types";
 function EditableItem({ item, setItem, onSave, onCancel, isLink, isExpense, apiKey, tripLocation, language, t, model, showNotification }) {
     const [isGeneratingDesc, setIsGeneratingDesc] = useState(false);
     const textAreaRef = useRef(null);
@@ -62,5 +63,20 @@ function EditableItem({ item, setItem, onSave, onCancel, isLink, isExpense, apiK
         </li>
     );
 }
+
+EditableItem.propTypes = {
+    item: PropTypes.object.isRequired,
+    setItem: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    isLink: PropTypes.bool,
+    isExpense: PropTypes.bool,
+    apiKey: PropTypes.string,
+    tripLocation: PropTypes.string,
+    language: PropTypes.string,
+    t: PropTypes.object.isRequired,
+    model: PropTypes.string,
+    showNotification: PropTypes.func.isRequired,
+};
 
 export default EditableItem;

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { CheckCircleIcon, CircleIcon, EditIcon, TrashIcon } from "./icons";
+import PropTypes from "prop-types";
 function ListItem({ item, onEdit, onDelete, onToggleComplete, isLink }) {
     const [isExpanded, setIsExpanded] = useState(false);
 
@@ -38,3 +39,11 @@ function ListItem({ item, onEdit, onDelete, onToggleComplete, isLink }) {
 }
 
 export default ListItem;
+
+ListItem.propTypes = {
+    item: PropTypes.object.isRequired,
+    onEdit: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    onToggleComplete: PropTypes.func.isRequired,
+    isLink: PropTypes.bool,
+};

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { AlertTriangleIcon, InfoIcon, CheckCircleIcon, PlusIcon } from "./icons";
+import PropTypes from "prop-types";
 function Notification({ notification, onClear }) {
     const { message, type } = notification || {};
     
@@ -37,3 +38,11 @@ function Notification({ notification, onClear }) {
     );
 }
 export default Notification;
+
+Notification.propTypes = {
+  notification: PropTypes.shape({
+    message: PropTypes.string,
+    type: PropTypes.string,
+  }),
+  onClear: PropTypes.func.isRequired,
+};

--- a/src/components/SectionDetail.js
+++ b/src/components/SectionDetail.js
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { PlusIcon, SparklesIcon } from "./icons";
 import ListItem from "./ListItem";
 import EditableItem from "./EditableItem";
+import PropTypes from "prop-types";
 function SectionDetail({ title, items, placeholder, updateSectionItems, isLink = false, isExpense = false, apiKey, aiPrompt, aiSchema, tripLocation, language, t, model, showNotification }) {
     const [inputValue, setInputValue] = useState('');
     const [inputValue2, setInputValue2] = useState('');
@@ -110,3 +111,20 @@ function SectionDetail({ title, items, placeholder, updateSectionItems, isLink =
 }
 
 export default SectionDetail;
+
+SectionDetail.propTypes = {
+    title: PropTypes.string.isRequired,
+    items: PropTypes.array.isRequired,
+    placeholder: PropTypes.string.isRequired,
+    updateSectionItems: PropTypes.func.isRequired,
+    isLink: PropTypes.bool,
+    isExpense: PropTypes.bool,
+    apiKey: PropTypes.string,
+    aiPrompt: PropTypes.string,
+    aiSchema: PropTypes.object,
+    tripLocation: PropTypes.string,
+    language: PropTypes.string,
+    t: PropTypes.object.isRequired,
+    model: PropTypes.string,
+    showNotification: PropTypes.func.isRequired,
+};

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import BaseModal from './BaseModal';
 import { LANGUAGES, PREDEFINED_MODELS } from '../constants/languages';
 import { COUNTRIES } from '../constants/countries';
@@ -69,3 +70,17 @@ export default function SettingsModal({ isOpen, onClose, apiKey, setApiKey, home
     </BaseModal>
   );
 }
+
+SettingsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  apiKey: PropTypes.string,
+  setApiKey: PropTypes.func.isRequired,
+  homeLocation: PropTypes.string,
+  setHomeLocation: PropTypes.func.isRequired,
+  language: PropTypes.string.isRequired,
+  setLanguage: PropTypes.func.isRequired,
+  model: PropTypes.string.isRequired,
+  setModel: PropTypes.func.isRequired,
+  t: PropTypes.object.isRequired,
+};

--- a/src/components/TripCard.js
+++ b/src/components/TripCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { MapPinIcon, CalendarIcon, EditIcon, CheckCircleIcon, CircleIcon } from './icons';
 
 export default function TripCard({ trip, onNavigate, onEdit, onSelect, isSelected }) {
@@ -23,3 +24,11 @@ export default function TripCard({ trip, onNavigate, onEdit, onSelect, isSelecte
     </div>
   );
 }
+
+TripCard.propTypes = {
+  trip: PropTypes.object.isRequired,
+  onNavigate: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  isSelected: PropTypes.bool,
+};

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 function PlusIcon({className}) { return (<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>); }
 function MapPinIcon() { return (<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>); }
 function CalendarIcon() { return (<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>); }
@@ -17,6 +18,13 @@ function CircleIcon({ className }) { return <svg className={className} width="24
 function CheckCircleIcon({ className }) { return <svg className={className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>; }
 function AlertTriangleIcon() { return <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>}
 function InfoIcon() { return <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>}
+
+PlusIcon.propTypes = { className: PropTypes.string };
+SparklesIcon.propTypes = { className: PropTypes.string };
+TrashIcon.propTypes = { className: PropTypes.string };
+EditIcon.propTypes = { className: PropTypes.string };
+CircleIcon.propTypes = { className: PropTypes.string };
+CheckCircleIcon.propTypes = { className: PropTypes.string };
 
 
 export { PlusIcon, MapPinIcon, CalendarIcon, ArrowLeftIcon, SparklesIcon, SettingsIcon, TrashIcon, EditIcon, SunIcon, MoonIcon, SuitcaseIcon, CameraIcon, LinkIcon, WalletIcon, FolderPlusIcon, CircleIcon, CheckCircleIcon, AlertTriangleIcon, InfoIcon };

--- a/src/screens/AppHeader.js
+++ b/src/screens/AppHeader.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { PlusIcon, SettingsIcon, MoonIcon, SunIcon } from "../components/icons";
 function AppHeader({ onNewTrip, onSettings, toggleTheme, theme, t }) {
     return (
@@ -22,3 +23,11 @@ function AppHeader({ onNewTrip, onSettings, toggleTheme, theme, t }) {
 }
 
 export default AppHeader;
+
+AppHeader.propTypes = {
+    onNewTrip: PropTypes.func.isRequired,
+    onSettings: PropTypes.func.isRequired,
+    toggleTheme: PropTypes.func.isRequired,
+    theme: PropTypes.string.isRequired,
+    t: PropTypes.object.isRequired,
+};

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -6,6 +6,7 @@ import EditTripModal from "../components/EditTripModal";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { db } from "../firebase/firebase";
 import { TrashIcon } from "../components/icons";
+import PropTypes from "prop-types";
 function HomeScreen({ userId, onSelectTrip, t }) {
     const [trips, setTrips] = useState([]);
     const [editingTrip, setEditingTrip] = useState(null);
@@ -102,3 +103,9 @@ function HomeScreen({ userId, onSelectTrip, t }) {
 }
 
 export default HomeScreen;
+
+HomeScreen.propTypes = {
+    userId: PropTypes.string,
+    onSelectTrip: PropTypes.func.isRequired,
+    t: PropTypes.object.isRequired,
+};

--- a/src/screens/SectionScreen.js
+++ b/src/screens/SectionScreen.js
@@ -3,6 +3,7 @@ import { onSnapshot, updateDoc, doc } from "firebase/firestore";
 import SectionDetail from "../components/SectionDetail";
 import { db } from "../firebase/firebase";
 import { ArrowLeftIcon } from "../components/icons";
+import PropTypes from "prop-types";
 function SectionScreen({ userId, tripId, sectionId, onBack, apiKey, language, t, model, showNotification }) {
     const [trip, setTrip] = useState(null);
     useEffect(() => {
@@ -56,3 +57,15 @@ function SectionScreen({ userId, tripId, sectionId, onBack, apiKey, language, t,
 
 // --- Компоненты ---
 export default SectionScreen;
+
+SectionScreen.propTypes = {
+    userId: PropTypes.string.isRequired,
+    tripId: PropTypes.string.isRequired,
+    sectionId: PropTypes.string.isRequired,
+    onBack: PropTypes.func.isRequired,
+    apiKey: PropTypes.string,
+    language: PropTypes.string,
+    t: PropTypes.object.isRequired,
+    model: PropTypes.string,
+    showNotification: PropTypes.func.isRequired,
+};

--- a/src/screens/TripScreen.js
+++ b/src/screens/TripScreen.js
@@ -5,6 +5,7 @@ import EditTripModal from "../components/EditTripModal";
 import AddSectionModal from "../components/AddSectionModal";
 import { db } from "../firebase/firebase";
 import { ArrowLeftIcon, SuitcaseIcon, CameraIcon, LinkIcon, WalletIcon, PlusIcon, FolderPlusIcon, EditIcon, MapPinIcon, CalendarIcon } from "../components/icons";
+import PropTypes from "prop-types";
 function TripScreen({ userId, tripId, onSelectSection, onBack, t, showNotification }) {
     const [trip, setTrip] = useState(null);
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -82,3 +83,12 @@ function TripScreen({ userId, tripId, onSelectSection, onBack, t, showNotificati
 }
 
 export default TripScreen;
+
+TripScreen.propTypes = {
+    userId: PropTypes.string.isRequired,
+    tripId: PropTypes.string.isRequired,
+    onSelectSection: PropTypes.func.isRequired,
+    onBack: PropTypes.func.isRequired,
+    t: PropTypes.object.isRequired,
+    showNotification: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## Summary
- install `prop-types`
- define PropTypes for components in `src/components`
- define PropTypes for screens in `src/screens`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855dd13f7f88326b92c1c2810380752